### PR TITLE
Enable wheel to reverse

### DIFF
--- a/nirmitsu_ros2_flowgraph/src/datatypes/WheelData.cpp
+++ b/nirmitsu_ros2_flowgraph/src/datatypes/WheelData.cpp
@@ -56,8 +56,8 @@ QString WheelData::to_string() const
   return QStringLiteral("Name: %1\nSpeed: %2\nReverse: %3")
     .arg(_value.name)
     .arg(QString::number(_value.speed)
-    .arg(_value.reverse ? QStringLiteral("True") : QStringLiteral("False"))
-  );
+      .arg(_value.reverse ? QStringLiteral("True") : QStringLiteral("False"))
+    );
 }
 
 //=============================================================================

--- a/nirmitsu_ros2_flowgraph/src/datatypes/WheelData.cpp
+++ b/nirmitsu_ros2_flowgraph/src/datatypes/WheelData.cpp
@@ -53,9 +53,11 @@ WheelData& WheelData::value(WheelDataType value)
 //=============================================================================
 QString WheelData::to_string() const
 {
-  return QStringLiteral("Name: %1\nSpeed: %2")
+  return QStringLiteral("Name: %1\nSpeed: %2\nReverse: %3")
     .arg(_value.name)
-    .arg(QString::number(_value.speed));
+    .arg(QString::number(_value.speed)
+    .arg(_value.reverse ? QStringLiteral("True") : QStringLiteral("False"))
+  );
 }
 
 //=============================================================================
@@ -69,5 +71,12 @@ WheelData& WheelData::set_speed(int speed)
 WheelData& WheelData::set_name(QString name)
 {
   _value.name = std::move(name);
+  return *this;
+}
+
+//=============================================================================
+WheelData& WheelData::set_reverse(bool reverse)
+{
+  _value.reverse = reverse;
   return *this;
 }

--- a/nirmitsu_ros2_flowgraph/src/datatypes/WheelData.hpp
+++ b/nirmitsu_ros2_flowgraph/src/datatypes/WheelData.hpp
@@ -28,17 +28,21 @@ struct WheelDataType
 {
   QString name;
   int speed;
+  bool reverse;
 
   WheelDataType()
   : name(QString()),
-    speed(0)
+    speed(0),
+    reverse(false)
   {}
 
   WheelDataType(
     QString name_,
-    int speed_)
+    int speed_,
+    bool reverse_)
   : name(std::move(name_)),
-    speed(speed_)
+    speed(speed_),
+    reverse(reverse_)
   {}
 };
 
@@ -56,6 +60,7 @@ public:
 
   WheelData& set_name(QString name);
   WheelData& set_speed(int speed);
+  WheelData& set_reverse(bool reverse);
 
 private:
   WheelDataType _value;

--- a/nirmitsu_ros2_flowgraph/src/robot/Robot.cpp
+++ b/nirmitsu_ros2_flowgraph/src/robot/Robot.cpp
@@ -70,9 +70,10 @@ Robot::Robot()
           auto msg = std::make_unique<Twist>();
           msg->header.stamp = data->_node->get_clock()->now();
           const auto& value = data->_wheel_1_data->value();
+          const int dir = value.reverse ? -1 : 1;
           msg->header.frame_id = value.name.toStdString();
           msg->twist.linear.x =
-          data->_on_data->value() ? value.speed / 100.0 : 0.0;
+          data->_on_data->value() ? dir * value.speed / 100.0 : 0.0;
           data->_pub->publish(std::move(msg));
 
         }
@@ -82,9 +83,10 @@ Robot::Robot()
           auto msg = std::make_unique<Twist>();
           msg->header.stamp = data->_node->get_clock()->now();
           const auto& value = data->_wheel_2_data->value();
+          const int dir = value.reverse ? -1 : 1;
           msg->header.frame_id = value.name.toStdString();
           msg->twist.linear.x =
-          data->_on_data->value() ? value.speed / 100.0 : 0.0;
+          data->_on_data->value() ? dir * value.speed / 100.0 : 0.0;
           data->_pub->publish(std::move(msg));
         }
 

--- a/nirmitsu_ros2_flowgraph/src/robot/RobotWheel.cpp
+++ b/nirmitsu_ros2_flowgraph/src/robot/RobotWheel.cpp
@@ -21,9 +21,11 @@
 RobotWheel::RobotWheel()
 : _label(new QLabel()),
   _string_data(std::make_shared<StringData>()),
-  _wheel_data(nullptr),
   _speed_data(nullptr),
-  _name_data(nullptr)
+  _name_data(nullptr),
+  _reverse_data(std::make_shared<BoolData>(false)),
+  _wheel_data(nullptr)
+
 {
   _label->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
 }
@@ -32,7 +34,7 @@ RobotWheel::RobotWheel()
 unsigned int RobotWheel::nPorts(PortType portType) const
 {
   if (portType == PortType::In)
-    return 2;
+    return 3;
   else if (portType == PortType::Out)
     return 2;
   else
@@ -48,6 +50,8 @@ QString RobotWheel::portCaption(PortType portType, PortIndex portIndex) const
       return QStringLiteral("Name");
     else if (portIndex == 1)
       return QStringLiteral("Speed");
+    else if (portIndex == 2)
+      return QStringLiteral("Reverse");
     else
       return QString();
   }
@@ -80,6 +84,11 @@ NodeDataType RobotWheel::dataType(PortType portType, PortIndex portIndex) const
     else if (portIndex == 1)
     {
       return IntegerData().type();
+    }
+    // Reverse
+    else if (portIndex == 2)
+    {
+      return BoolData().type();
     }
     else
     {
@@ -132,19 +141,31 @@ void RobotWheel::setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
     if (_wheel_data != nullptr)
       _wheel_data->set_speed(_speed_data->value());
   }
+  // Reverse
+  else if (portIndex == 2)
+  {
+    auto reverse_data = std::dynamic_pointer_cast<BoolData>(data);
+    if (reverse_data == nullptr)
+      return;
+    _reverse_data = std::move(reverse_data);
+    if (_wheel_data != nullptr)
+      _wheel_data->set_reverse(_reverse_data->value());
+  }
   else
   {
     return;
   }
 
-  // Create or update wheel data
+  // Create or update wheel data if both name and speed are provided.
   if (_wheel_data == nullptr)
   {
     if (_name_data != nullptr && _speed_data != nullptr)
     {
       _wheel_data = std::make_shared<WheelData>(WheelDataType(
             _name_data->value(),
-            _speed_data->value()));
+            _speed_data->value(),
+            _reverse_data->value()
+      ));
       _string_data->value(_wheel_data->to_string());
       Q_EMIT dataUpdated(0);
       Q_EMIT dataUpdated(1);

--- a/nirmitsu_ros2_flowgraph/src/robot/RobotWheel.cpp
+++ b/nirmitsu_ros2_flowgraph/src/robot/RobotWheel.cpp
@@ -25,7 +25,6 @@ RobotWheel::RobotWheel()
   _name_data(nullptr),
   _reverse_data(std::make_shared<BoolData>(false)),
   _wheel_data(nullptr)
-
 {
   _label->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
 }

--- a/nirmitsu_ros2_flowgraph/src/robot/RobotWheel.hpp
+++ b/nirmitsu_ros2_flowgraph/src/robot/RobotWheel.hpp
@@ -29,6 +29,7 @@
 #include "../datatypes/StringData.hpp"
 #include "../datatypes/IntegerData.hpp"
 #include "../datatypes/WheelData.hpp"
+#include "../datatypes/BoolData.hpp"
 
 using QtNodes::PortType;
 using QtNodes::PortIndex;
@@ -88,6 +89,7 @@ private:
   std::shared_ptr<StringData> _string_data;
   std::shared_ptr<StringData> _name_data;
   std::shared_ptr<IntegerData> _speed_data;
+  std::shared_ptr<BoolData> _reverse_data;
   std::shared_ptr<WheelData> _wheel_data;
 };
 


### PR DESCRIPTION
This PR updates the WheelData datatype to include a boolean for reversing. The `Robot` node is also updated to change the polarity of the wheel's linear velocity.